### PR TITLE
Fix session ID format inconsistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "post-cortex"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src/tools/mcp/mod.rs
+++ b/src/tools/mcp/mod.rs
@@ -2519,7 +2519,7 @@ pub async fn semantic_search_global(
                 message.push_str(&format!(
                     "{}. [Session: {}] [{:?}] Similarity: {:.1}% | Relevance: {:.1}% ({})\n",
                     idx + 1,
-                    &r.session_id.to_string()[..8],
+                    &r.session_id.to_string(),
                     r.content_type,
                     r.similarity_score * 100.0,
                     r.combined_score * 100.0,


### PR DESCRIPTION
## Summary
   - Fixed session ID format inconsistency in `semantic_search_global` output messages
   - Changed from displaying 8-character prefixes to full 36-character UUIDs
   - Resolves UX issue where users copied short IDs and received validation errors

   ## Problem
   The `semantic_search` tool displayed shortened session IDs (first 8 characters) in human-readable output messages, but all other MCP tools
   (`get_structured_summary`, `query_conversation_context`, `update_conversation_context`) require full 36-character UUIDs. This created a UX trap where users
   naturally copied the short ID from the message and received validation errors when attempting to use it in other tools.

   **Example Error:**
   ```
   MCP error -32602: invalid length: expected length 32 for simple format, found 8
   ```

   ## Solution
   **Single-line change** in `src/tools/mcp/mod.rs:2522`:

   ```rust
   // Before:
   &r.session_id.to_string()[..8]

   // After:
   &r.session_id.to_string()
   ```

   ## Changes
   - Remove string slicing `[..8]` from session_id display in message output
   - Display full 36-character UUIDs (RFC 9562 compliant)
   - JSON responses already correctly returned full UUIDs (no changes needed)

   ## Impact
   - ✅ **Low risk**: Display-only change, no data structure modifications
   - ✅ **No breaking changes**: JSON responses already return full UUIDs
   - ✅ **Resolves ambiguity**: Sessions with same 8-char prefix no longer confused
   - ✅ **Standards compliant**: Follows RFC 9562 and MCP ecosystem conventions
   - ✅ **All tests pass**: 98/98 tests successful

   ## Testing
   - All existing unit tests pass (98/98)
   - Release build successful
   - Verified no other semantic search variants affected

   ## References
   - **RFC 9562**: UUID canonical format is 36-character hyphenated string
   - **MCP Rust SDK**: Uses full UUIDs throughout
   - **Related code**:
     - `src/tools/mcp/mod.rs:2522` - Fixed short ID display
     - `src/daemon/mcp_service.rs:219,288,348,434` - UUID validation (requires full format)
     - `src/tools/mcp/mod.rs:2550,2723,2820` - JSON responses (correctly return full UUIDs)