### PR TITLE
fix: dedup entity graph edges + unify MCP/gRPC network paths

### DIFF
--- a/crates/post-cortex-core/src/graph/entity_graph.rs
+++ b/crates/post-cortex-core/src/graph/entity_graph.rs
@@ -435,23 +435,41 @@ impl SimpleEntityGraph {
             .push(update_id);
     }
 
-    /// Add relationship - now uses petgraph for efficient storage
+    /// Add relationship - idempotent on (from, to, relation_type).
+    ///
+    /// petgraph treats `add_edge` as multigraph insert (always creates a new
+    /// EdgeIndex), so repeated calls with the same triple would accumulate
+    /// parallel edges. We scan existing edges between the endpoints and
+    /// update the context in place if one matches the relation type;
+    /// otherwise we add a fresh edge.
     pub fn add_relationship(&mut self, relationship: EntityRelationship) {
         let timestamp = Utc::now();
 
-        // Use safe helper to get or create nodes - no more unwrap()!
         let from_node =
             self.get_or_create_node(&relationship.from_entity, EntityType::Concept, timestamp);
-
         let to_node =
             self.get_or_create_node(&relationship.to_entity, EntityType::Concept, timestamp);
 
-        // Add edge to graph with full EdgeData (includes context)
-        let edge_data = EdgeData {
-            relation_type: relationship.relation_type,
-            context: relationship.context,
-        };
-        self.graph.add_edge(from_node, to_node, edge_data);
+        let existing = self
+            .graph
+            .edges_connecting(from_node, to_node)
+            .find(|edge| edge.weight().relation_type == relationship.relation_type)
+            .map(|edge| edge.id());
+
+        match existing {
+            Some(edge_id) => {
+                if let Some(weight) = self.graph.edge_weight_mut(edge_id) {
+                    weight.context = relationship.context;
+                }
+            }
+            None => {
+                let edge_data = EdgeData {
+                    relation_type: relationship.relation_type,
+                    context: relationship.context,
+                };
+                self.graph.add_edge(from_node, to_node, edge_data);
+            }
+        }
     }
 
     /// Merge all entities and relationships from another graph into this one.
@@ -1169,6 +1187,66 @@ mod tests {
         assert_eq!(stats.edge_count, 2);
         assert_eq!(stats.entity_count, 3);
         assert!(stats.avg_degree > 0.0);
+    }
+
+    #[test]
+    fn test_add_relationship_is_idempotent_on_same_triple() {
+        let mut graph = create_test_graph();
+        let baseline_edges = graph.get_graph_stats().edge_count;
+
+        // Re-add the same (from, to, relation_type) several times with new contexts.
+        for ctx in ["first repeat", "second repeat", "third repeat"] {
+            graph.add_relationship(EntityRelationship {
+                from_entity: "rust".to_string(),
+                to_entity: "petgraph".to_string(),
+                relation_type: RelationType::Implements,
+                context: ctx.to_string(),
+            });
+        }
+
+        assert_eq!(
+            graph.get_graph_stats().edge_count,
+            baseline_edges,
+            "Repeated (from, to, relation_type) must not accumulate parallel edges"
+        );
+
+        let all_rels = graph.get_all_relationships();
+        let rust_to_petgraph: Vec<_> = all_rels
+            .iter()
+            .filter(|r| {
+                r.from_entity == "rust"
+                    && r.to_entity == "petgraph"
+                    && r.relation_type == RelationType::Implements
+            })
+            .collect();
+        assert_eq!(rust_to_petgraph.len(), 1, "Exactly one edge expected");
+        assert_eq!(
+            rust_to_petgraph[0].context, "third repeat",
+            "Context should be updated to the latest value"
+        );
+    }
+
+    #[test]
+    fn test_add_relationship_keeps_distinct_relation_types() {
+        let mut graph = SimpleEntityGraph::new();
+        graph.add_or_update_entity("a".to_string(), EntityType::Concept, Utc::now(), "");
+        graph.add_or_update_entity("b".to_string(), EntityType::Concept, Utc::now(), "");
+
+        for rt in [
+            RelationType::DependsOn,
+            RelationType::Implements,
+            RelationType::RelatedTo,
+        ] {
+            graph.add_relationship(EntityRelationship {
+                from_entity: "a".to_string(),
+                to_entity: "b".to_string(),
+                relation_type: rt,
+                context: "".to_string(),
+            });
+        }
+
+        // Distinct relation types between the same pair are legitimate multi-edges.
+        assert_eq!(graph.get_graph_stats().edge_count, 3);
     }
 
     #[test]

--- a/crates/post-cortex-mcp/src/analysis.rs
+++ b/crates/post-cortex-mcp/src/analysis.rs
@@ -200,10 +200,26 @@ pub async fn get_entity_network_view(
     let max_entities = max_entities.unwrap_or(50);
     let max_relationships = max_relationships.unwrap_or(100);
 
-    let entities: Vec<serde_json::Value> = session
-        .entity_graph
-        .get_most_important_entities(max_entities)
-        .into_iter()
+    // Resolve the BFS center identically to the gRPC handler so both transports
+    // hit the same dedup'd code path in SimpleEntityGraph::get_entity_network.
+    let resolved_center = match center_entity.as_deref() {
+        Some(name) if !name.is_empty() => Some(name.to_string()),
+        _ => session
+            .entity_graph
+            .get_most_important_entities(1)
+            .first()
+            .map(|e| e.name.clone()),
+    };
+
+    let network = match resolved_center.as_deref() {
+        Some(center) => session.entity_graph.get_entity_network(center, 2),
+        None => session.entity_graph.get_entity_network("", 2),
+    };
+
+    let entities: Vec<serde_json::Value> = network
+        .entities
+        .values()
+        .take(max_entities)
         .map(|e| {
             serde_json::json!({
                 "name": e.name,
@@ -214,35 +230,18 @@ pub async fn get_entity_network_view(
         })
         .collect();
 
-    let relationships: Vec<serde_json::Value> = if let Some(center) = &center_entity {
-        session
-            .entity_graph
-            .trace_entity_relationships(center, 2)
-            .into_iter()
-            .take(max_relationships)
-            .map(|(entity, rel_type, target)| {
-                serde_json::json!({
-                    "from": entity,
-                    "type": format!("{:?}", rel_type),
-                    "to": target
-                })
+    let relationships: Vec<serde_json::Value> = network
+        .relationships
+        .iter()
+        .take(max_relationships)
+        .map(|r| {
+            serde_json::json!({
+                "from": r.from_entity,
+                "type": format!("{:?}", r.relation_type),
+                "to": r.to_entity
             })
-            .collect()
-    } else {
-        session
-            .entity_graph
-            .get_all_relationships()
-            .into_iter()
-            .take(max_relationships)
-            .map(|r| {
-                serde_json::json!({
-                    "from": r.from_entity,
-                    "type": format!("{:?}", r.relation_type),
-                    "to": r.to_entity
-                })
-            })
-            .collect()
-    };
+        })
+        .collect();
 
     Ok(MCPToolResult::success(
         format!(
@@ -252,7 +251,7 @@ pub async fn get_entity_network_view(
         ),
         Some(serde_json::json!({
             "session_id": session_id,
-            "center_entity": center_entity,
+            "center_entity": resolved_center,
             "entities": entities,
             "relationships": relationships
         })),


### PR DESCRIPTION
add_relationship now scans graph.edges_connecting for an existing edge with the same relation_type and updates its context in place instead of appending a parallel edge. petgraph's add_edge is a multigraph insert, so repeated update_conversation_context calls with the same triple were silently bloating the underlying graph storage.

get_entity_network_view (MCP) now routes through SimpleEntityGraph:: get_entity_network the same way the gRPC handler already does, dropping the old trace_entity_relationships / get_all_relationships split. Both transports now hit the same dedup'd BFS code path with HashSet<(from, to, RelationType)>.

Adds two regression tests: repeated (from, to, relation_type) keeps edge_count stable and updates context to latest; distinct relation types between the same pair still produce separate edges.