### PR TITLE
security: drop permissive CORS layer from local daemon HTTP router

### DIFF
--- a/crates/post-cortex-daemon/src/daemon/server/mod.rs
+++ b/crates/post-cortex-daemon/src/daemon/server/mod.rs
@@ -38,7 +38,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
-use tower_http::cors::CorsLayer;
 use tracing::{debug, info};
 use uuid::Uuid;
 
@@ -171,7 +170,12 @@ impl DaemonServer {
                 "/api/workspaces/{workspace_id}/sessions/{session_id}",
                 post(rest::api_attach_session),
             )
-            .layer(CorsLayer::permissive())
+            // No CORS layer: the daemon is a local-only service that exposes
+            // raw session/workspace payloads. With permissive CORS, any web page
+            // the user visits could fetch http://127.0.0.1:3737/api/sessions
+            // and exfiltrate memory data. Omitting the layer means axum sends
+            // no Access-Control-Allow-* headers, so browsers refuse all
+            // cross-origin requests. Native MCP/gRPC clients are unaffected.
             .with_state(server)
     }
 


### PR DESCRIPTION
CorsLayer::permissive() set Access-Control-Allow-Origin: * with all methods and headers on the legacy HTTP router that exposes /api/sessions, /api/workspaces, /sse, /message, /stats, /health. The daemon binds to 127.0.0.1 by default, but any browser tab on the same machine could still fetch http://127.0.0.1:3737/api/sessions and read full session payloads (cross-origin data exfiltration via the user's browser).

Removing the layer entirely. Axum then sends no Access-Control-Allow-* headers, so browsers refuse cross-origin requests. Native MCP and gRPC clients are unaffected.

Closes #15.